### PR TITLE
Add graphwm to data and config paths

### DIFF
--- a/graphwm/conf/data/chain.yaml
+++ b/graphwm/conf/data/chain.yaml
@@ -13,7 +13,7 @@ datamodule:
 
     train:
       _target_: graphwm.data.PolymerDataset
-      split: ${oc.env:PROJECT_ROOT}/splits/chain/train.txt
+      split: ${oc.env:PROJECT_ROOT}/graphwm/splits/chain/train.txt
       directory: ${data.dir}
       dilation: ${model.dilation}
       seq_len: ${model.seq_len}
@@ -23,7 +23,7 @@ datamodule:
 
     val:
       - _target_: graphwm.data.PolymerDataset
-        split: ${oc.env:PROJECT_ROOT}/splits/chain/val.txt 
+        split: ${oc.env:PROJECT_ROOT}/graphwm/splits/chain/val.txt
         directory: ${data.dir}
         dilation: ${model.dilation}
         seq_len: ${model.seq_len}
@@ -33,7 +33,7 @@ datamodule:
   
     test:
       - _target_: graphwm.data.PolymerDataset
-        split: ${oc.env:PROJECT_ROOT}/splits/chain/val.txt 
+        split: ${oc.env:PROJECT_ROOT}/graphwm/splits/chain/val.txt
         directory: ${data.dir}
         dilation: ${model.dilation}
         seq_len: ${model.seq_len}

--- a/graphwm/train.py
+++ b/graphwm/train.py
@@ -160,7 +160,7 @@ def run(cfg: DictConfig) -> None:
         wandb_logger.experiment.finish()
 
 
-@hydra.main(config_path=str(PROJECT_ROOT / "conf"), config_name="train")
+@hydra.main(config_path=str(PROJECT_ROOT / "graphwm"/ "conf"), config_name="train")
 def main(cfg: omegaconf.DictConfig):
     run(cfg)
 


### PR DESCRIPTION
Errors from before minor fixes:

In train:
```
Primary config directory not found.
Check that the config directory '/mlcgmd/conf' exists and readable
```

In chain.yaml:
```
FileNotFoundError: Error instantiating 'graphwm.data.datamodule.PLDataModule' : Error instantiating 'graphwm.data.data.PolymerDataset' : [Errno 2] No such file or directory: ' /mlcgmd/splits/chain/train.txt'
```